### PR TITLE
Healthcheck timeout suggestions

### DIFF
--- a/api/types/container/config.go
+++ b/api/types/container/config.go
@@ -47,7 +47,7 @@ type HealthConfig struct {
 	Interval    time.Duration `json:",omitempty"` // Interval is the time to wait between checks.
 	Timeout     time.Duration `json:",omitempty"` // Timeout is the time to wait before considering the check to have hung.
 	StartPeriod time.Duration `json:",omitempty"` // The start period for the container to initialize before the retries starts to count down.
-	StopTimeout time.Duration `json:",omitempty"` // StopTimeout is the time to wait for exec process to stop before sending SIGKILL.
+	StopTimeout time.Duration `json:"-"`          // StopTimeout is the time to wait for exec process to stop before sending SIGKILL. It is currently only used for integration tests.
 
 	// Retries is the number of consecutive failures needed to consider a container as unhealthy.
 	// Zero means inherit.
@@ -59,8 +59,7 @@ type ExecStartOptions struct {
 	Stdin       io.Reader
 	Stdout      io.Writer
 	Stderr      io.Writer
-	ConsoleSize *[2]uint      `json:",omitempty"`
-	StopTimeout time.Duration `json:",omitempty"` // StopTimeout is the time to wait for exec process to stop before sending SIGKILL.
+	ConsoleSize *[2]uint `json:",omitempty"`
 }
 
 // Config contains the configuration data about a container.

--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -301,8 +301,8 @@ func (daemon *Daemon) ContainerExecStart(ctx context.Context, name string, optio
 		daemon.containerd.SignalProcess(sigCtx, c.ID, name, signal.SignalMap["TERM"])
 
 		wait := termProcessTimeout
-		if options.StopTimeout != 0 {
-			wait = options.StopTimeout
+		if ec.StopTimeout != nil {
+			wait = *ec.StopTimeout
 		}
 		timeout := time.NewTimer(wait)
 		defer timeout.Stop()

--- a/daemon/exec/exec.go
+++ b/daemon/exec/exec.go
@@ -37,7 +37,7 @@ type Config struct {
 	Env          []string
 	Pid          int
 	ConsoleSize  *[2]uint
-	StopTimeout  *time.Duration // StopTimeout is the timeout to wait for exec process to stop before sending SIGKILL.
+	StopTimeout  time.Duration // StopTimeout is the timeout to wait for exec process to stop before sending SIGKILL.
 }
 
 // NewConfig initializes the a new exec configuration

--- a/daemon/exec/exec.go
+++ b/daemon/exec/exec.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"runtime"
 	"sync"
+	"time"
 
 	"github.com/containerd/containerd/cio"
 	"github.com/docker/docker/container/stream"
@@ -36,6 +37,7 @@ type Config struct {
 	Env          []string
 	Pid          int
 	ConsoleSize  *[2]uint
+	StopTimeout  *time.Duration // StopTimeout is the timeout to wait for exec process to stop before sending SIGKILL.
 }
 
 // NewConfig initializes the a new exec configuration

--- a/daemon/health.go
+++ b/daemon/health.go
@@ -81,7 +81,8 @@ func (p *cmdProbe) run(ctx context.Context, d *Daemon, cntr *container.Container
 	execConfig.Privileged = false
 	execConfig.User = cntr.Config.User
 	execConfig.WorkingDir = cntr.Config.WorkingDir
-	execConfig.StopTimeout = &cntr.Config.Healthcheck.StopTimeout
+	// health checks don't get the full 10 seconds timeout for a .
+	execConfig.StopTimeout = 500 * time.Millisecond
 
 	linkedEnv, err := d.setupLinkedContainers(cntr)
 	if err != nil {

--- a/daemon/health.go
+++ b/daemon/health.go
@@ -81,6 +81,7 @@ func (p *cmdProbe) run(ctx context.Context, d *Daemon, cntr *container.Container
 	execConfig.Privileged = false
 	execConfig.User = cntr.Config.User
 	execConfig.WorkingDir = cntr.Config.WorkingDir
+	execConfig.StopTimeout = &cntr.Config.Healthcheck.StopTimeout
 
 	linkedEnv, err := d.setupLinkedContainers(cntr)
 	if err != nil {
@@ -100,9 +101,8 @@ func (p *cmdProbe) run(ctx context.Context, d *Daemon, cntr *container.Container
 	execErr := make(chan error, 1)
 
 	options := containertypes.ExecStartOptions{
-		Stdout:      output,
-		Stderr:      output,
-		StopTimeout: cntr.Config.Healthcheck.StopTimeout,
+		Stdout: output,
+		Stderr: output,
 	}
 
 	go func() { execErr <- d.ContainerExecStart(probeCtx, execConfig.ID, options) }()

--- a/integration/container/health_test.go
+++ b/integration/container/health_test.go
@@ -103,11 +103,10 @@ func TestHealthCheckProcessKilled(t *testing.T) {
 
 	cID := container.Run(ctx, t, client, func(c *container.TestContainerConfig) {
 		c.Config.Healthcheck = &containertypes.HealthConfig{
-			Test:        []string{"CMD-SHELL", "sh -c 'trap \"echo SIGTERM\" 15; sleep 30 & pid=$!; while jobs %% >/dev/null; do wait $pid; done'"},
-			Interval:    100 * time.Millisecond,
-			Timeout:     50 * time.Millisecond,
-			StopTimeout: 10 * time.Millisecond,
-			Retries:     1,
+			Test:     []string{"CMD-SHELL", "sh -c 'trap \"echo SIGTERM\" 15; sleep 30 & pid=$!; while jobs %% >/dev/null; do wait $pid; done'"},
+			Interval: 100 * time.Millisecond,
+			Timeout:  50 * time.Millisecond,
+			Retries:  1,
 		}
 	})
 	poll.WaitOn(t, pollForHealthCheckLog(ctx, client, cID, "Health check exceeded timeout (50ms):\nSIGTERM\n"))


### PR DESCRIPTION
Some suggestions / alternatives;

### 1. set StopTimeout on exec create, not exec start

Similar to how StopTimeout for containers is part of the container's
definition, and because the timeout is defined as part of the
HealthConfig, we should probably make this part of the exec's
config.

### 2. healthcheck: give health checks a short stop-timeout as default

health checks are not expected to do extensive changes, so shouldn't
need a full 10 seconds timeout to stop gracefully on failure, so
set a shorter (0.5 seconds currently) timeout.
