### PR TITLE
healtcheck timeout changes

### DIFF
--- a/api/types/container/config.go
+++ b/api/types/container/config.go
@@ -47,7 +47,6 @@ type HealthConfig struct {
 	Interval    time.Duration `json:",omitempty"` // Interval is the time to wait between checks.
 	Timeout     time.Duration `json:",omitempty"` // Timeout is the time to wait before considering the check to have hung.
 	StartPeriod time.Duration `json:",omitempty"` // The start period for the container to initialize before the retries starts to count down.
-	StopTimeout time.Duration `json:"-"`          // StopTimeout is the time to wait for exec process to stop before sending SIGKILL. It is currently only used for integration tests.
 
 	// Retries is the number of consecutive failures needed to consider a container as unhealthy.
 	// Zero means inherit.

--- a/api/types/container/config.go
+++ b/api/types/container/config.go
@@ -47,6 +47,7 @@ type HealthConfig struct {
 	Interval    time.Duration `json:",omitempty"` // Interval is the time to wait between checks.
 	Timeout     time.Duration `json:",omitempty"` // Timeout is the time to wait before considering the check to have hung.
 	StartPeriod time.Duration `json:",omitempty"` // The start period for the container to initialize before the retries starts to count down.
+	StopTimeout time.Duration `json:",omitempty"` // StopTimeout is the time to wait for exec process to stop before sending SIGKILL.
 
 	// Retries is the number of consecutive failures needed to consider a container as unhealthy.
 	// Zero means inherit.
@@ -58,7 +59,8 @@ type ExecStartOptions struct {
 	Stdin       io.Reader
 	Stdout      io.Writer
 	Stderr      io.Writer
-	ConsoleSize *[2]uint `json:",omitempty"`
+	ConsoleSize *[2]uint      `json:",omitempty"`
+	StopTimeout time.Duration `json:",omitempty"` // StopTimeout is the time to wait for exec process to stop before sending SIGKILL.
 }
 
 // Config contains the configuration data about a container.

--- a/api/types/container/config.go
+++ b/api/types/container/config.go
@@ -47,7 +47,7 @@ type HealthConfig struct {
 	Interval    time.Duration `json:",omitempty"` // Interval is the time to wait between checks.
 	Timeout     time.Duration `json:",omitempty"` // Timeout is the time to wait before considering the check to have hung.
 	StartPeriod time.Duration `json:",omitempty"` // The start period for the container to initialize before the retries starts to count down.
-	StopTimeout time.Duration `json:",omitempty"` // StopTimeout is the time to wait for exec process to stop before sending SIGKILL.
+	StopTimeout time.Duration `json:"-"`          // StopTimeout is the time to wait for exec process to stop before sending SIGKILL. It is currently only used for integration tests.
 
 	// Retries is the number of consecutive failures needed to consider a container as unhealthy.
 	// Zero means inherit.
@@ -59,8 +59,7 @@ type ExecStartOptions struct {
 	Stdin       io.Reader
 	Stdout      io.Writer
 	Stderr      io.Writer
-	ConsoleSize *[2]uint      `json:",omitempty"`
-	StopTimeout time.Duration `json:",omitempty"` // StopTimeout is the time to wait for exec process to stop before sending SIGKILL.
+	ConsoleSize *[2]uint `json:",omitempty"`
 }
 
 // Config contains the configuration data about a container.

--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -272,7 +272,10 @@ func (daemon *Daemon) ContainerExecStart(ctx context.Context, name string, optio
 		CloseStdin: true,
 	}
 	ec.StreamConfig.AttachStreams(&attachConfig)
-	attachErr := ec.StreamConfig.CopyStreams(ctx, &attachConfig)
+	// using context.Background() so that we can wait for exec completion even after ctx cancellation
+	copyCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	attachErr := ec.StreamConfig.CopyStreams(copyCtx, &attachConfig)
 
 	// Synchronize with libcontainerd event loop
 	ec.Lock()
@@ -293,15 +296,22 @@ func (daemon *Daemon) ContainerExecStart(ctx context.Context, name string, optio
 	select {
 	case <-ctx.Done():
 		logrus.Debugf("Sending TERM signal to process %v in container %v", name, c.ID)
-		daemon.containerd.SignalProcess(ctx, c.ID, name, signal.SignalMap["TERM"])
+		sigCtx, cancelFunc := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancelFunc()
+		daemon.containerd.SignalProcess(sigCtx, c.ID, name, signal.SignalMap["TERM"])
 
-		timeout := time.NewTimer(termProcessTimeout)
+		wait := termProcessTimeout
+		if options.StopTimeout != 0 {
+			wait = options.StopTimeout
+		}
+		timeout := time.NewTimer(wait)
 		defer timeout.Stop()
-
 		select {
 		case <-timeout.C:
 			logrus.Infof("Container %v, process %v failed to exit within %v of signal TERM - using the force", c.ID, name, termProcessTimeout)
-			daemon.containerd.SignalProcess(ctx, c.ID, name, signal.SignalMap["KILL"])
+			sigCtx, cancelFunc = context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancelFunc()
+			daemon.containerd.SignalProcess(sigCtx, c.ID, name, signal.SignalMap["KILL"])
 		case <-attachErr:
 			// TERM signal worked
 		}

--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -301,8 +301,8 @@ func (daemon *Daemon) ContainerExecStart(ctx context.Context, name string, optio
 		daemon.containerd.SignalProcess(sigCtx, c.ID, name, signal.SignalMap["TERM"])
 
 		wait := termProcessTimeout
-		if options.StopTimeout != 0 {
-			wait = options.StopTimeout
+		if ec.StopTimeout != 0 {
+			wait = ec.StopTimeout
 		}
 		timeout := time.NewTimer(wait)
 		defer timeout.Stop()

--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -126,6 +126,7 @@ func (daemon *Daemon) ContainerExecCreate(name string, config *types.ExecConfig)
 	execConfig.Privileged = config.Privileged
 	execConfig.User = config.User
 	execConfig.WorkingDir = config.WorkingDir
+	execConfig.StopTimeout = termProcessTimeout
 
 	linkedEnv, err := daemon.setupLinkedContainers(cntr)
 	if err != nil {
@@ -300,11 +301,7 @@ func (daemon *Daemon) ContainerExecStart(ctx context.Context, name string, optio
 		defer cancelFunc()
 		daemon.containerd.SignalProcess(sigCtx, c.ID, name, signal.SignalMap["TERM"])
 
-		wait := termProcessTimeout
-		if ec.StopTimeout != 0 {
-			wait = ec.StopTimeout
-		}
-		timeout := time.NewTimer(wait)
+		timeout := time.NewTimer(ec.StopTimeout)
 		defer timeout.Stop()
 		select {
 		case <-timeout.C:

--- a/daemon/exec/exec.go
+++ b/daemon/exec/exec.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"runtime"
 	"sync"
+	"time"
 
 	"github.com/containerd/containerd/cio"
 	"github.com/docker/docker/container/stream"
@@ -36,6 +37,7 @@ type Config struct {
 	Env          []string
 	Pid          int
 	ConsoleSize  *[2]uint
+	StopTimeout  time.Duration // StopTimeout is the timeout to wait for exec process to stop before sending SIGKILL.
 }
 
 // NewConfig initializes the a new exec configuration

--- a/daemon/health.go
+++ b/daemon/health.go
@@ -100,8 +100,9 @@ func (p *cmdProbe) run(ctx context.Context, d *Daemon, cntr *container.Container
 	execErr := make(chan error, 1)
 
 	options := containertypes.ExecStartOptions{
-		Stdout: output,
-		Stderr: output,
+		Stdout:      output,
+		Stderr:      output,
+		StopTimeout: cntr.Config.Healthcheck.StopTimeout,
 	}
 
 	go func() { execErr <- d.ContainerExecStart(probeCtx, execConfig.ID, options) }()
@@ -136,9 +137,16 @@ func (p *cmdProbe) run(ctx context.Context, d *Daemon, cntr *container.Container
 		// Wait for probe to exit (it might take a while to respond to the TERM
 		// signal and we don't want dying probes to pile up).
 		<-execErr
+		out := output.String()
+		var msg string
+		if len(out) > 0 {
+			msg = fmt.Sprintf("Health check exceeded timeout (%v):\n%s", probeTimeout, out)
+		} else {
+			msg = fmt.Sprintf("Health check exceeded timeout (%v)", probeTimeout)
+		}
 		return &types.HealthcheckResult{
 			ExitCode: -1,
-			Output:   fmt.Sprintf("Health check exceeded timeout (%v)", probeTimeout),
+			Output:   msg,
 			End:      time.Now(),
 		}, nil
 	case err := <-execErr:

--- a/daemon/health.go
+++ b/daemon/health.go
@@ -81,6 +81,11 @@ func (p *cmdProbe) run(ctx context.Context, d *Daemon, cntr *container.Container
 	execConfig.Privileged = false
 	execConfig.User = cntr.Config.User
 	execConfig.WorkingDir = cntr.Config.WorkingDir
+	// health checks don't get the full 10 seconds timeout to stop gracefully.
+	execConfig.StopTimeout = 500 * time.Millisecond
+	if cntr.Config.Healthcheck.StopTimeout != 0 {
+		execConfig.StopTimeout = cntr.Config.Healthcheck.StopTimeout
+	}
 
 	linkedEnv, err := d.setupLinkedContainers(cntr)
 	if err != nil {
@@ -100,9 +105,8 @@ func (p *cmdProbe) run(ctx context.Context, d *Daemon, cntr *container.Container
 	execErr := make(chan error, 1)
 
 	options := containertypes.ExecStartOptions{
-		Stdout:      output,
-		Stderr:      output,
-		StopTimeout: cntr.Config.Healthcheck.StopTimeout,
+		Stdout: output,
+		Stderr: output,
 	}
 
 	go func() { execErr <- d.ContainerExecStart(probeCtx, execConfig.ID, options) }()

--- a/daemon/health.go
+++ b/daemon/health.go
@@ -83,9 +83,6 @@ func (p *cmdProbe) run(ctx context.Context, d *Daemon, cntr *container.Container
 	execConfig.WorkingDir = cntr.Config.WorkingDir
 	// health checks don't get the full 10 seconds timeout to stop gracefully.
 	execConfig.StopTimeout = 500 * time.Millisecond
-	if cntr.Config.Healthcheck.StopTimeout != 0 {
-		execConfig.StopTimeout = cntr.Config.Healthcheck.StopTimeout
-	}
 
 	linkedEnv, err := d.setupLinkedContainers(cntr)
 	if err != nil {

--- a/integration/container/health_test.go
+++ b/integration/container/health_test.go
@@ -103,11 +103,10 @@ func TestHealthCheckProcessKilled(t *testing.T) {
 
 	cID := container.Run(ctx, t, client, func(c *container.TestContainerConfig) {
 		c.Config.Healthcheck = &containertypes.HealthConfig{
-			Test:        []string{"CMD-SHELL", "sh -c 'trap \"echo SIGTERM\" 15; sleep 30 & pid=$!; while jobs %% >/dev/null; do wait $pid; done'"},
-			Interval:    100 * time.Millisecond,
-			Timeout:     50 * time.Millisecond,
-			Retries:     1,
-			StopTimeout: 20 * time.Millisecond,
+			Test:     []string{"CMD-SHELL", "sh -c 'trap \"echo SIGTERM\" 15; sleep 30 & pid=$!; while jobs %% >/dev/null; do wait $pid; done'"},
+			Interval: 100 * time.Millisecond,
+			Timeout:  50 * time.Millisecond,
+			Retries:  1,
 		}
 	})
 	poll.WaitOn(t, pollForHealthCheckLog(ctx, client, cID, "Health check exceeded timeout (50ms):\nSIGTERM\n"))

--- a/integration/container/health_test.go
+++ b/integration/container/health_test.go
@@ -2,6 +2,7 @@ package container // import "github.com/docker/docker/integration/container"
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -91,6 +92,43 @@ while true; do sleep 1; done
 	ctxPoll, cancel = context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 	poll.WaitOn(t, pollForHealthStatus(ctxPoll, client, id, "healthy"), poll.WithDelay(100*time.Millisecond))
+}
+
+// TestHealthCheckProcessKilled verifies that health-checks exec get killed on time-out.
+func TestHealthCheckProcessKilled(t *testing.T) {
+	skip.If(t, testEnv.OSType == "windows", "FIXME")
+	defer setupTest(t)()
+	ctx := context.Background()
+	client := testEnv.APIClient()
+
+	cID := container.Run(ctx, t, client, func(c *container.TestContainerConfig) {
+		c.Config.Healthcheck = &containertypes.HealthConfig{
+			Test:        []string{"CMD-SHELL", "sh -c 'trap \"echo SIGTERM\" 15; sleep 30 & pid=$!; while jobs %% >/dev/null; do wait $pid; done'"},
+			Interval:    100 * time.Millisecond,
+			Timeout:     50 * time.Millisecond,
+			StopTimeout: 10 * time.Millisecond,
+			Retries:     1,
+		}
+	})
+	poll.WaitOn(t, pollForHealthCheckLog(ctx, client, cID, "Health check exceeded timeout (50ms):\nSIGTERM\n"))
+}
+
+func pollForHealthCheckLog(ctx context.Context, client client.APIClient, containerID string, expected string) func(log poll.LogT) poll.Result {
+	return func(log poll.LogT) poll.Result {
+		inspect, err := client.ContainerInspect(ctx, containerID)
+		if err != nil {
+			return poll.Error(err)
+		}
+		healthChecksTotal := len(inspect.State.Health.Log)
+		if healthChecksTotal > 0 {
+			output := inspect.State.Health.Log[healthChecksTotal-1].Output
+			if output == expected {
+				return poll.Success()
+			}
+			return poll.Error(fmt.Errorf("expected %q, got %q", expected, output))
+		}
+		return poll.Continue("waiting for container healthcheck logs")
+	}
 }
 
 func pollForHealthStatus(ctx context.Context, client client.APIClient, containerID string, healthStatus string) func(log poll.LogT) poll.Result {

--- a/integration/container/health_test.go
+++ b/integration/container/health_test.go
@@ -106,8 +106,8 @@ func TestHealthCheckProcessKilled(t *testing.T) {
 			Test:        []string{"CMD-SHELL", "sh -c 'trap \"echo SIGTERM\" 15; sleep 30 & pid=$!; while jobs %% >/dev/null; do wait $pid; done'"},
 			Interval:    100 * time.Millisecond,
 			Timeout:     50 * time.Millisecond,
-			StopTimeout: 10 * time.Millisecond,
 			Retries:     1,
+			StopTimeout: 20 * time.Millisecond,
 		}
 	})
 	poll.WaitOn(t, pollForHealthCheckLog(ctx, client, cID, "Health check exceeded timeout (50ms):\nSIGTERM\n"))


### PR DESCRIPTION
- Set the timeout for regular "exec" on ContainerExecCreate,
  so that we can expect it to always be there on ContainerExecStart
- Remove the HealthConfig.StopTimeout field, as it was only used in
  a test, and with the new (short) timeout for healthchecks may not
  be needed.

To verify the test still works;

    make DOCKER_STORAGE_DRIVER=vfs TEST_FILTER=TestHealthCheckProcessKilled test-integration

